### PR TITLE
Include details in errors

### DIFF
--- a/test/Microsoft.Azure.Mobile.Server.Files.Test.EndToEnd/App_Start/Startup.MobileApp.cs
+++ b/test/Microsoft.Azure.Mobile.Server.Files.Test.EndToEnd/App_Start/Startup.MobileApp.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Azure.Mobile.Server.Files.Test.EndToEnd
         public static void ConfigureMobileApp(IAppBuilder app)
         {
             HttpConfiguration config = new HttpConfiguration();
+            config.IncludeErrorDetailPolicy = IncludeErrorDetailPolicy.Always;
 
             new MobileAppConfiguration()
                 .UseDefaultConfiguration()


### PR DESCRIPTION
Setting IncludeErrorDetailPolicy will make it easier to debug the tests 